### PR TITLE
[JITERA] Implement DELETE /books/:id API Endpoint

### DIFF
--- a/src/pages/api/books/[id].ts
+++ b/src/pages/api/books/[id].ts
@@ -1,0 +1,34 @@
+// src/pages/api/books/[id].ts
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// Dummy in-memory data store (replace with DB access layer)
+let books: { id: string; [key: string]: any }[] = []; // Replace with proper DB/model in implementation
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  // Validate HTTP method
+  if (req.method !== 'DELETE') {
+    res.setHeader('Allow', ['DELETE']);
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+
+  // Extract and validate book id
+  const { id } = req.query;
+  if (!id || typeof id !== 'string') {
+    return res.status(400).json({ message: 'Invalid or missing book ID.' });
+  }
+
+  // Remove book from store (replace with actual DB operation)
+  const index = books.findIndex((book) => book.id === id);
+
+  if (index === -1) {
+    // Book not found
+    return res.status(404).json({ message: 'Book not found.' });
+  }
+
+  // Delete the book
+  books.splice(index, 1);
+
+  // Success response
+  return res.status(200).json({ message: 'Book deleted successfully.' });
+}


### PR DESCRIPTION
## Overview
This pull request introduces a new API endpoint for deleting a book by its ID in a Next.js application. The implementation follows the Next.js conventions for API routes and includes necessary validations and response handling.

## Changes
- **File Created**: `src/pages/api/books/[id].ts`
  - This file implements the DELETE `/books/:id` API endpoint.
  
- **HTTP Method Validation**: 
  - The API checks if the request method is DELETE. If not, it responds with a `405 Method Not Allowed` status.

- **ID Validation**: 
  - The API extracts the book ID from the request query and validates it. If the ID is missing or invalid, it responds with a `400 Bad Request` status.

- **Book Deletion Logic**: 
  - The API searches for the book in a dummy in-memory data store. If the book is not found, it responds with a `404 Not Found` status.
  - If the book is found, it is removed from the store, and a success message is returned with a `200 OK` status.

- **Response Codes**: 
  - The implementation adheres to the specified response codes and messages for different scenarios.

## Notes
- The current implementation uses a dummy in-memory data store. It is recommended to replace this with actual database access logic as per your project's architecture.
- No authentication is required for this endpoint, as specified in the requirements.

Please review the changes and let me know if any adjustments are needed!
